### PR TITLE
Conditionally preserve default constructors

### DIFF
--- a/src/essential-interfaces-generator/Tasks/ImplementationGenerator.cs
+++ b/src/essential-interfaces-generator/Tasks/ImplementationGenerator.cs
@@ -16,7 +16,7 @@ namespace EssentialInterfaces.Tasks
         private const string BaseImplementationInterface = "IEssentialsImplementation";
 
         private readonly List<string> _usings
-            = new[] { "System", "System.Collections.Generic", "System.IO", "System.Threading", "System.Threading.Tasks", InterfacesNamespace }.ToList();
+            = new[] { "System", "System.Collections.Generic", "System.IO", "System.Threading", "System.Threading.Tasks", "Essential.Interfaces", InterfacesNamespace }.ToList();
             
         public string Generate(GeneratorContext context, List<ApiModel> models)
         {
@@ -50,13 +50,15 @@ namespace EssentialInterfaces.Tasks
 
         public string GetCombinedImplementationCode(List<ApiModel> models)
             => $"public class {ImplementationClass} : {BaseImplementationInterface}, {String.Join(", ", models.Select(i => i.Interface))} {{ {Environment.NewLine}{Environment.NewLine}" +
-               String.Join($"{Environment.NewLine}{Environment.NewLine}", models.SelectMany(x => x.Declarations, GetForwardedImplementation)).Indent() + Environment.NewLine +
+               $"[Preserve(Conditional=true)]{Environment.NewLine}public {ImplementationClass}() {{}}{Environment.NewLine}{Environment.NewLine}".Indent() +
+               String.Join($"{Environment.NewLine}{Environment.NewLine}", models.SelectMany(x => x.Declarations, GetForwardedImplementation)) + Environment.NewLine +
                $"}}";
 
         public string GetSingleApiImplementationCode(ApiModel m)
         {
             return $"public class {m.Api}Implementation : {BaseImplementationInterface}, {m.Interface} {{ {Environment.NewLine}{Environment.NewLine}" +
-                   String.Join($"{Environment.NewLine}{Environment.NewLine}", m.Declarations.Select(d => GetForwardedImplementation(m, d))).Indent() + Environment.NewLine +
+                   $"[Preserve(Conditional=true)]{Environment.NewLine}public {m.Api}Implementation() {{}}{Environment.NewLine}{Environment.NewLine}".Indent() +
+                   String.Join($"{Environment.NewLine}{Environment.NewLine}", m.Declarations.Select(d => GetForwardedImplementation(m, d))) + Environment.NewLine +
                    $"}}";
         }
 

--- a/src/output/Essential.Interfaces/LinkerSafe.cs
+++ b/src/output/Essential.Interfaces/LinkerSafe.cs
@@ -1,7 +1,26 @@
-﻿using Essential.Interfaces;
+﻿using System;
+using System.ComponentModel;
+using Essential.Interfaces;
 
 [assembly: LinkerSafe]
 namespace Essential.Interfaces
 {
     class LinkerSafeAttribute : System.Attribute { }
+
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class PreserveAttribute : Attribute
+    {
+        public bool AllMembers;
+		public bool Conditional;
+
+		public PreserveAttribute(bool allMembers, bool conditional)
+		{
+			AllMembers = allMembers;
+			Conditional = conditional;
+		}
+
+		public PreserveAttribute()
+		{
+		}
+    }
 }


### PR DESCRIPTION
Thank you for creating this library, it's just what we needed 😃 

When registering the implementation types in our DI container, we often do this by the type, for example:
```csharp
builder.RegisterType<FlashlightImplementation>().As<IFlashlight>().SingleInstance();
```
Which we would expect to work, and the assembly is marked as "linker safe". However what happens here is that the mono linker decides that no-one is using the default constructor, so it removes it.

This PR conditionally preserves the constructors, meaning that if the type isn't used at all, it will still get removed, but otherwise implementation class will always keep their constructor.

Marked as WIP cause I have yet to test it.